### PR TITLE
Improvement: Instance Index ID is derived from Module Index

### DIFF
--- a/MMM-SimpleText.js
+++ b/MMM-SimpleText.js
@@ -61,15 +61,15 @@ Module.register('MMM-SimpleText', {
             return filePath;
         };
         
-		iInstanceID=this.data.index;
+        iInstanceID=this.data.index;
 		
-		Log.log("MMM-SimpleText Instance ID:" + iInstanceID );
-		var uniqueID="MMM-SimpleText-"+iInstanceID
-		this.uniqueID=uniqueID; 
+        Log.log("MMM-SimpleText Instance ID:" + iInstanceID );
+        var uniqueID="MMM-SimpleText-"+iInstanceID
+        this.uniqueID=uniqueID; 
 
         var contentDiv = document.createElement("div");
 
-		contentDiv.id = uniqueID;
+        contentDiv.id = uniqueID;
         contentDiv.innerHTML = getText();
 
         dom.style.fontFamily = getFont();
@@ -86,7 +86,7 @@ Module.register('MMM-SimpleText', {
             var self = this;
             this.readFileContent(function (response) {
                 self.config.fileContent["value"] = response.replace(/(?:\r\n|\r|\n)/g, '<br>');
-				document.getElementById(self.uniqueID).innerHTML = self.config.fileContent["value"];
+                document.getElementById(self.uniqueID).innerHTML = self.config.fileContent["value"];
             });
         }
 
@@ -99,7 +99,7 @@ Module.register('MMM-SimpleText', {
             var self = this;
             this.readFileContent(function (response) {
                 self.config.fileContent["value"] = response.replace(/(?:\r\n|\r|\n)/g, '<br>');
-				document.getElementById(self.uniqueID).innerHTML = self.config.fileContent["value"];
+                document.getElementById(self.uniqueID).innerHTML = self.config.fileContent["value"];
             });
         }
 

--- a/MMM-SimpleText.js
+++ b/MMM-SimpleText.js
@@ -27,7 +27,7 @@ Module.register('MMM-SimpleText', {
         },
 		UniqueID:
 		{
-            "value": "0"
+            "value": "MMM-SimpleText-0"
         },		
     },
 

--- a/MMM-SimpleText.js
+++ b/MMM-SimpleText.js
@@ -25,10 +25,6 @@ Module.register('MMM-SimpleText', {
         fileContent: {
             "value": ""
         },
-		UniqueID:
-		{
-            "value": "MMM-SimpleText-0"
-        },		
     },
 
     //override dom generator.
@@ -65,15 +61,15 @@ Module.register('MMM-SimpleText', {
             return filePath;
         };
         
-		var getUniqueID = () => {
-            var UniqueID = this.config.UniqueID["value"];
-            return UniqueID;
-        };		
-
-
+		iInstanceID=this.data.index;
+		
+		Log.log("MMM-SimpleText Instance ID:" + iInstanceID );
+		var uniqueID="MMM-SimpleText-"+iInstanceID
+		this.uniqueID=uniqueID; 
 
         var contentDiv = document.createElement("div");
-        contentDiv.id = getUniqueID();
+
+		contentDiv.id = uniqueID;
         contentDiv.innerHTML = getText();
 
         dom.style.fontFamily = getFont();
@@ -90,7 +86,7 @@ Module.register('MMM-SimpleText', {
             var self = this;
             this.readFileContent(function (response) {
                 self.config.fileContent["value"] = response.replace(/(?:\r\n|\r|\n)/g, '<br>');
-                document.getElementById(self.config.UniqueID["value"]).innerHTML = self.config.fileContent["value"];
+				document.getElementById(self.uniqueID).innerHTML = self.config.fileContent["value"];
             });
         }
 
@@ -103,7 +99,7 @@ Module.register('MMM-SimpleText', {
             var self = this;
             this.readFileContent(function (response) {
                 self.config.fileContent["value"] = response.replace(/(?:\r\n|\r|\n)/g, '<br>');
-                document.getElementById(self.config.UniqueID["value"]).innerHTML = self.config.fileContent["value"];
+				document.getElementById(self.uniqueID).innerHTML = self.config.fileContent["value"];
             });
         }
 

--- a/MMM-SimpleText.js
+++ b/MMM-SimpleText.js
@@ -25,6 +25,10 @@ Module.register('MMM-SimpleText', {
         fileContent: {
             "value": ""
         },
+		UniqueID:
+		{
+            "value": "0"
+        },		
     },
 
     //override dom generator.
@@ -60,10 +64,16 @@ Module.register('MMM-SimpleText', {
             var filePath = this.config.filePath["value"];
             return filePath;
         };
+        
+		var getUniqueID = () => {
+            var UniqueID = this.config.UniqueID["value"];
+            return UniqueID;
+        };		
+
 
 
         var contentDiv = document.createElement("div");
-        contentDiv.id = "MMM-SimpleText-content";
+        contentDiv.id = getUniqueID();
         contentDiv.innerHTML = getText();
 
         dom.style.fontFamily = getFont();
@@ -73,14 +83,14 @@ Module.register('MMM-SimpleText', {
 
         dom.appendChild(contentDiv);
 
-
+		
 
         //Read file content if path has been given
         if (getFilePath() !== "") {
             var self = this;
             this.readFileContent(function (response) {
                 self.config.fileContent["value"] = response.replace(/(?:\r\n|\r|\n)/g, '<br>');
-                document.getElementById("MMM-SimpleText-content").innerHTML = self.config.fileContent["value"];
+                document.getElementById(self.config.UniqueID["value"]).innerHTML = self.config.fileContent["value"];
             });
         }
 
@@ -93,7 +103,7 @@ Module.register('MMM-SimpleText', {
             var self = this;
             this.readFileContent(function (response) {
                 self.config.fileContent["value"] = response.replace(/(?:\r\n|\r|\n)/g, '<br>');
-                document.getElementById("MMM-SimpleText-content").innerHTML = self.config.fileContent["value"];
+                document.getElementById(self.config.UniqueID["value"]).innerHTML = self.config.fileContent["value"];
             });
         }
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ Below you can find a complete example with those two properties beeing used:
 			filePath: {
 			  'value': 'test.txt'
 			},
+                        UniqueID: {
+                          'value': '1'
+                        },
 		}
 },
 ```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ filePath: {
 module in config.js assign an unique ID to each
 ```
 UniqueID: {
-  'value': '1'
+  'value': 'MMM-SimpleText-0'
 },
 ```
 
@@ -127,7 +127,7 @@ Below you can find a complete example with those two properties beeing used:
 			  'value': 'test.txt'
 			},
                         UniqueID: {
-                          'value': '1'
+                          'value': 'MMM-SimpleText-0'
                         },
 		}
 },

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ filePath: {
   'value': 'test.txt'
 },
 ```
+3. **Multiple module definitions** - to have more then one MMM-SimpleText
+module in config.js assign an unique ID to each
+```
+UniqueID: {
+  'value': '1'
+},
+```
+
 
 
 **Linebreaks** - When reading text from a file, line breaks will be included

--- a/README.md
+++ b/README.md
@@ -88,14 +88,6 @@ filePath: {
   'value': 'test.txt'
 },
 ```
-3. **Multiple module definitions** - to have more then one MMM-SimpleText
-module in config.js assign an unique ID to each
-```
-UniqueID: {
-  'value': 'MMM-SimpleText-0'
-},
-```
-
 
 
 **Linebreaks** - When reading text from a file, line breaks will be included
@@ -126,9 +118,6 @@ Below you can find a complete example with those two properties beeing used:
 			filePath: {
 			  'value': 'test.txt'
 			},
-                        UniqueID: {
-                          'value': 'MMM-SimpleText-0'
-                        },
 		}
 },
 ```


### PR DESCRIPTION
UniqueID is no longer necessary when using multple instances of MMM-SimpleText. The ID is derived from the MagicMirror module index.